### PR TITLE
Verbesserung der strukturierten Daten

### DIFF
--- a/header.php
+++ b/header.php
@@ -67,10 +67,11 @@ _/  |_ |  |__    ____    ____   _____   |  | __  _  _______   ___.__.  ______ \_
         <header id="masthead" class="site-header cf"> 
             <div class="site-header-content">
                     <div id="site-branding" role="banner" itemprop="publisher" itemscope itemtype="http://schema.org/Organization">
+                            <?php echo pirate_rogue_create_schema_publisher(false) ?>
                             <?php if ( is_front_page() ) : ?>
-                                    <h1 class="site-title" itemprop="name"><?php bloginfo( 'name' ); ?></h1>
+                                    <h1 class="site-title"><?php bloginfo( 'name' ); ?></h1>
                             <?php else : ?>
-                                    <p class="site-title" itemprop="name"><a href="<?php echo esc_url( home_url( '/' ) ); ?>" rel="home" itemprop="url"><?php bloginfo( 'name' ); ?></a></p>
+                                    <p class="site-title"><a href="<?php echo esc_url( home_url( '/' ) ); ?>" rel="home"><?php bloginfo( 'name' ); ?></a></p>
                             <?php endif; ?>
 
                             <?php if ( has_custom_logo() ) : ?>
@@ -113,7 +114,7 @@ _/  |_ |  |__    ____    ____   _____   |  | __  _  _______   ___.__.  ______ \_
 
             </div><!-- .site-header-content -->
 
-            <div class="sticky-header hidden" itemprop="publisher" itemscope itemtype="http://schema.org/Organization">
+            <div class="sticky-header hidden">
                     <button id="overlay-open-sticky" class="overlay-open overlay-btn"><span><?php esc_html_e( 'Menu', 'pirate-rogue'); ?></span></button>
                     <?php if ( '' == get_theme_mod( 'pirate_rogue_hidesearch' ) ) : ?>
                             <button id="search-open-sticky" class="search-open search-btn"><span><?php esc_html_e( 'Search', 'pirate-rogue'); ?></span></button>
@@ -124,7 +125,7 @@ _/  |_ |  |__    ____    ____   _____   |  | __  _  _______   ___.__.  ______ \_
                              <?php the_custom_logo(); ?>
                      </div><!-- end .custom-logo-wrap -->
                     <?php else : ?>
-                            <p class="site-title" itemprop="name"><a href="<?php echo esc_url( home_url( '/' ) ); ?>" rel="home" itemprop="url"><?php bloginfo( 'name' ); ?></a></p>
+                            <p class="site-title"><a href="<?php echo esc_url( home_url( '/' ) ); ?>" rel="home"><?php bloginfo( 'name' ); ?></a></p>
                     <?php endif; ?>
 
 

--- a/inc/custom-header.php
+++ b/inc/custom-header.php
@@ -53,15 +53,11 @@ if ( ! function_exists( 'pirate_rogue_get_custom_logo' ) ) :
             }
 	    $html .= '>';
 	    $html .=  wp_get_attachment_image( $custom_logo_id, 'full', false, array(
-		    'class'    => $imgclass,
-		    'itemprop' => 'logo',
+		    'class'    => $imgclass
 		) );
 
 	  
             $html .= '</a>';
-	   if ( is_front_page() ) {
-               $html .= '<meta itemprop="url" content="'.esc_url( home_url( '/' ) ).'">';
-           }
 	 } elseif ( is_customize_preview() ) {
 	    // If no logo is set but we're in the Customizer, leave a placeholder (needed for the live preview).
 	    $html = sprintf( '<a href="%1$s" class="custom-logo-link" style="display:none;"><img class="custom-logo"/></a>',

--- a/inc/template-functions.php
+++ b/inc/template-functions.php
@@ -659,7 +659,7 @@ function pirate_rogue_create_schema_publisher($withrahmen = true) {
         $out .= '<meta itemprop="height" content="'.$height.'">';
         $out .= '</div>';
     }
-    $out .= '<meta itemprop="name" content="'.get_bloginfo( 'title' ).'">';
+    $out .= '<meta itemprop="name" content="'.get_bloginfo( 'name' ).'">';
     $out .= '<meta itemprop="url" content="'.home_url( '/' ).'">';
     if ($withrahmen) {
         $out .= '</div>';

--- a/inc/template-functions.php
+++ b/inc/template-functions.php
@@ -688,6 +688,29 @@ function pirate_rogue_create_schema_thumbnail($id = 0) {
 }
 
 /*-----------------------------------------------------------------------------------*/
+/*  Create String for Thumbnail info, used by Scema.org Microformat Data
+/*-----------------------------------------------------------------------------------*/
+function pirate_rogue_create_schema_postmeta($id = 0) {
+    $output = "";
+    if (!$id) {
+        $id = get_the_ID();
+    }
+    $output .= '<meta itemprop="datePublished" content="'.esc_attr( get_post_time('c', false, $id) ).'">';
+    $output .= '<meta itemprop="dateModified" content="'.esc_attr( get_the_modified_time('c', false, $id) ).'">';
+    
+    $author = get_theme_mod( 'pirate_rogue_author' );
+    if (!$author) {
+        $author_id = get_post_field('post_author', $id);
+        $author = get_the_author_meta( 'display_name' , $author_id ); 
+    }
+    $output .= '<div itemprop="author" itemscope itemtype="http://schema.org/Person">';
+    $output .= '<meta itemprop="name" content="'.$author.'">';
+    $output .= '</div>';
+    
+    return $output;
+}
+
+/*-----------------------------------------------------------------------------------*/
 /* Change output for gallery
 /*-----------------------------------------------------------------------------------*/
 add_filter('post_gallery', 'pirate_rogue_post_gallery', 10, 2);

--- a/inc/template-functions.php
+++ b/inc/template-functions.php
@@ -671,17 +671,16 @@ function pirate_rogue_create_schema_publisher($withrahmen = true) {
 /*-----------------------------------------------------------------------------------*/
 function pirate_rogue_create_schema_thumbnail($id = 0) {
     $output = "";
-    if (!isset($id)) {
+    if (!$id) {
         $id = get_the_ID();
     }
     $post_thumbnail_id = get_post_thumbnail_id( $id ); 
-    if ((!isset($post_thumbnail_id)) || ($post_thumbnail_id <= 0)) {
-        $thumbfallbackid = absint(get_theme_mod( 'pirate_rogue_fallback_blogroll_thumbnail' ));
-        if (isset($thumbfallbackid)) {
+    if (!$post_thumbnail_id) {
+        $thumbfallbackid = get_theme_mod( 'pirate_rogue_fallback_blogroll_thumbnail' );
+        if ($thumbfallbackid) {
            $post_thumbnail_id = $thumbfallbackid;
         }
     }
-  
     
     if ($post_thumbnail_id) {
         $thumbimage = wp_get_attachment_image_src( $post_thumbnail_id);

--- a/inc/template-functions.php
+++ b/inc/template-functions.php
@@ -368,148 +368,137 @@
  /* Add a special walker for the main menu, allowing us, to add some stuff :)
  /*-----------------------------------------------------------------------------------*/
  class Pirate_Rogue_Menu_Walker extends Walker_Nav_Menu {
-      public function start_el(&$output, $item, $depth = 0, $args = array(), $id = 0) {
-           if ( '-' === $item->title ) {
-                $item_output = '<li class="menu_separator"><hr>';
-           } else {     
-                global $wp_query;
-                $indent = ( $depth ) ? str_repeat( "\t", $depth ) : '';
+    public function start_el(&$output, $item, $depth = 0, $args = array(), $id = 0) {
+        if ( '-' === $item->title ) {
+            $item_output = '<li class="menu_separator"><hr>';
+        } else {
+            $indent = ( $depth ) ? str_repeat( "\t", $depth ) : '';
+            
+            $class_names = $attributes = '';
+            
+            $classes = empty( $item->classes ) ? array() : (array) $item->classes;
+            $ariapopup = '';
+            $rellink = '';
+            if (!empty($item->url)) {
+                $rellink = pirate_rogue_make_link_relative($item->url);
+                if (substr($rellink,0,4) == 'http') {
+                // absoluter Link auf externe Seite
+                $classes[] = 'external';
+                } elseif ($rellink == '/') {
+                // Link auf Startseite
+                $classes[] = 'homelink';
+                }                 
+            }
+            
+            if (in_array('has_children', $classes)) {
+                $ariapopup = ' aria-haspopup="true"';
+            }
+            $class_names = join( ' ', apply_filters( 'nav_menu_css_class', array_filter( $classes ), $item ) );
+            $class_names = ' class="'. esc_attr( $class_names ) . '"';
+            
+            $output .= $indent . '<li' . $class_names .$ariapopup.'>';
+            
+            $attributes  = ! empty( $item->attr_title ) ? ' title="'  . esc_attr( $item->attr_title ) .'"' : '';
+            $attributes .= ! empty( $item->target )     ? ' target="' . esc_attr( $item->target     ) .'"' : '';
+            $attributes .= ! empty( $item->xfn )        ? ' rel="'    . esc_attr( $item->xfn        ) .'"' : '';
+            $attributes .= ! empty( $item->url )        ? ' href="'   . esc_attr( $item->url        ) .'"' : '';
+            $description  = ! empty( $item->description ) ? '<span>'.esc_attr( $item->description ).'</span>' : '';
 
-                $class_names = $value = $attributes = '';
-
-                $classes = empty( $item->classes ) ? array() : (array) $item->classes;
-                $ariapopup = '';
-                $rellink = '';
-		if (!empty($item->url)) {		
-		    $rellink = pirate_rogue_make_link_relative($item->url);
-		    if (substr($rellink,0,4) == 'http') {
-			// absoluter Link auf externe Seite
-			$classes[] = 'external';
-		    } elseif ($rellink == '/') {
-			// Link auf Startseite
-			$classes[] = 'homelink';
-		    }                 
-		}
+            if($depth != 0) {
+                $description = "";
+            }
+            $item_output = '';
+            if (!empty($attributes)) {
+                if (!empty($args->before))
+                    $item_output .= $args->before;
+                $item_output .= '<a'. $attributes .'>';
                 
-                if (in_array('has_children', $classes)) {
-                    $ariapopup = ' aria-haspopup="true"';
-                }
-                $class_names = join( ' ', apply_filters( 'nav_menu_css_class', array_filter( $classes ), $item ) );
-                $class_names = ' class="'. esc_attr( $class_names ) . '"';
-
+                if (!empty($args->link_before)) 
+                    $item_output .= $args->link_before;
                 
-		               
-                
-                $output .= $indent . '<li ' . $value . $class_names .$ariapopup.'>';
-                
-                
-                $attributes  = ! empty( $item->attr_title ) ? ' title="'  . esc_attr( $item->attr_title ) .'"' : '';
-                $attributes .= ! empty( $item->target )     ? ' target="' . esc_attr( $item->target     ) .'"' : '';
-                $attributes .= ! empty( $item->xfn )        ? ' rel="'    . esc_attr( $item->xfn        ) .'"' : '';
-                $attributes .= ! empty( $item->url )        ? ' href="'   . esc_attr( $item->url        ) .'"' : '';
-                $description  = ! empty( $item->description ) ? '<span>'.esc_attr( $item->description ).'</span>' : '';
-
-                if($depth != 0) {
-                          $description = "";
-                }
-		$item_output = '';
-		if (!empty($args->before))
-		    $item_output .= $args->before;
-                 $item_output .= '<a'. $attributes .'>';
-                 
-		if (!empty($args->link_before)) 
-		    $item_output .= $args->link_before;
-		
-		$item_output .=apply_filters( 'the_title', $item->title, $item->ID );
+                $item_output .= apply_filters( 'the_title', $item->title, $item->ID );
                 $item_output .= $description;
                 
-		if (!empty($args->link_after)) 
-		    $item_output .= $args->link_after;                
+                if (!empty($args->link_after)) 
+                    $item_output .= $args->link_after;
                 
-		$item_output .= '</a>';
-		
-		 if (!empty($args->after))
-		    $item_output .= $args->after;
-           }
-           $output .= apply_filters( 'walker_nav_menu_start_el', $item_output, $item, $depth, $args );
-            
-       }
-        public function display_element($el, &$children, $max_depth, $depth = 0, $args = array(), &$output){
-        $id = $this->db_fields['id'];
-        if(isset($children[$el->$id]))
-            $el->classes[] = 'has_children';
-
-        parent::display_element($el, $children, $max_depth, $depth, $args, $output);
+                $item_output .= '</a>';
+                
+                if (!empty($args->after))
+                    $item_output .= $args->after;
+            }
+        }
+        $output .= apply_filters( 'walker_nav_menu_start_el', $item_output, $item, $depth, $args );
+    }
+    public function display_element($el, &$children, $max_depth, $depth = 0, $args = array(), &$output){
+    $id = $this->db_fields['id'];
+    if(isset($children[$el->$id]))
+        $el->classes[] = 'has_children';
+    
+    parent::display_element($el, $children, $max_depth, $depth, $args, $output);
     }
 }
  /*-----------------------------------------------------------------------------------*/
  /* Add a special walker for the main menu, allowing us, to add some stuff :)
  /*-----------------------------------------------------------------------------------*/
  class Pirate_Rogue_OverlayMenu_Walker extends Walker_Nav_Menu {
-      public function start_el(&$output, $item, $depth = 0, $args = array(), $id = 0) {
-           if ( '-' === $item->title ) {
-                $item_output = '<li class="menu_separator">';
-           } else {     
-                global $wp_query;
-                $indent = ( $depth ) ? str_repeat( "\t", $depth ) : '';
-
-                $class_names = $value = $attributes = '';
-
-                $classes = empty( $item->classes ) ? array() : (array) $item->classes;
-                $ariapopup = '';
-                if (in_array('has_children', $classes)) {
-                    $ariapopup = ' aria-haspopup="true"';
-                }
-                $class_names = join( ' ', apply_filters( 'nav_menu_css_class', array_filter( $classes ), $item ) );
-                $class_names = ' class="'. esc_attr( $class_names ) . '"';
-
-                
-                
-                
-                $attributes  = ! empty( $item->attr_title ) ? ' title="'  . esc_attr( $item->attr_title ) .'"' : '';
-                $attributes .= ! empty( $item->target )     ? ' target="' . esc_attr( $item->target     ) .'"' : '';
-                $attributes .= ! empty( $item->xfn )        ? ' rel="'    . esc_attr( $item->xfn        ) .'"' : '';
-                $attributes .= ! empty( $item->url )        ? ' href="'   . esc_attr( $item->url        ) .'"' : '';
-                $description  = ! empty( $item->description ) ? '<span>'.esc_attr( $item->description ).'</span>' : '';
-
-                if($depth != 0) {
-                          $description = "";
-                }
-		$item_output = '';
-		if (!empty($attributes)) {
-
-		    if (!empty($args->before))
-			$item_output .= $args->before;
-		     $item_output .= '<a'. $attributes .'>';
-
-		    if (!empty($args->link_before)) 
-			$item_output .= $args->link_before;
-
-		    $item_output .=apply_filters( 'the_title', $item->title, $item->ID );
-		    $item_output .= $description;
-
-		    if (!empty($args->link_after)) 
-			$item_output .= $args->link_after;                
-
-		    $item_output .= '</a>';
-
-		     if (!empty($args->after))
-			$item_output .= $args->after;
-                     
-                     
-                    $output .= $indent . '<li ' . $value . $class_names .$ariapopup.'>';
-		}
-           }
-           $output .= apply_filters( 'walker_nav_menu_start_el', $item_output, $item, $depth, $args );
+    public function start_el(&$output, $item, $depth = 0, $args = array(), $id = 0) {
+        if ( '-' === $item->title ) {
+            $item_output = '<li class="menu_separator">';
+        } else {
+            $indent = ( $depth ) ? str_repeat( "\t", $depth ) : '';
             
-       }
-        public function display_element($el, &$children, $max_depth, $depth = 0, $args = array(), &$output){
-	    $id = $this->db_fields['id'];
-	    if(isset($children[$el->$id]))
-		$el->classes[] = 'has_children';
+            $class_names = $attributes = '';
+            
+            $classes = empty( $item->classes ) ? array() : (array) $item->classes;
+            $ariapopup = '';
+            if (in_array('has_children', $classes)) {
+                $ariapopup = ' aria-haspopup="true"';
+            }
+            $class_names = join( ' ', apply_filters( 'nav_menu_css_class', array_filter( $classes ), $item ) );
+            $class_names = ' class="'. esc_attr( $class_names ) . '"';
+            
+            $output .= $indent . '<li' . $class_names .$ariapopup.'>';
+            
+            $attributes  = ! empty( $item->attr_title ) ? ' title="'  . esc_attr( $item->attr_title ) .'"' : '';
+            $attributes .= ! empty( $item->target )     ? ' target="' . esc_attr( $item->target     ) .'"' : '';
+            $attributes .= ! empty( $item->xfn )        ? ' rel="'    . esc_attr( $item->xfn        ) .'"' : '';
+            $attributes .= ! empty( $item->url )        ? ' href="'   . esc_attr( $item->url        ) .'"' : '';
+            $description  = ! empty( $item->description ) ? '<span>'.esc_attr( $item->description ).'</span>' : '';
 
-	    parent::display_element($el, $children, $max_depth, $depth, $args, $output);
-	}
+            if($depth != 0) {
+                $description = "";
+            }
+            $item_output = '';
+            if (!empty($attributes)) {
+                if (!empty($args->before))
+                    $item_output .= $args->before;
+                $item_output .= '<a'. $attributes .'>';
+                
+                if (!empty($args->link_before)) 
+                    $item_output .= $args->link_before;
+                
+                $item_output .= apply_filters( 'the_title', $item->title, $item->ID );
+                $item_output .= $description;
+                
+                if (!empty($args->link_after)) 
+                    $item_output .= $args->link_after;
+                
+                $item_output .= '</a>';
+                
+                if (!empty($args->after))
+                    $item_output .= $args->after;
+            }
+        }
+        $output .= apply_filters( 'walker_nav_menu_start_el', $item_output, $item, $depth, $args );
+    }
+    public function display_element($el, &$children, $max_depth, $depth = 0, $args = array(), &$output){
+    $id = $this->db_fields['id'];
+    if(isset($children[$el->$id]))
+        $el->classes[] = 'has_children';
+    
+    parent::display_element($el, $children, $max_depth, $depth, $args, $output);
+    }
 }
 /*-----------------------------------------------------------------------------------*/
 /* Get Image Meta Data

--- a/template-parts/content-blogroll.php
+++ b/template-parts/content-blogroll.php
@@ -60,5 +60,9 @@ if (!isset($thumbfallbackid)) {
 			</div>
                 </div>
 	</div>
-        <?php echo pirate_rogue_create_schema_thumbnail(); ?>
+    <?php 
+        echo pirate_rogue_create_schema_thumbnail(); 
+        echo pirate_rogue_create_schema_postmeta();
+        echo pirate_rogue_create_schema_publisher();
+    ?>
 </article>

--- a/template-parts/content-blogroll.php
+++ b/template-parts/content-blogroll.php
@@ -19,7 +19,7 @@ if (!isset($thumbfallbackid)) {
 
 <article <?php post_class('cf'); ?> itemscope itemtype="http://schema.org/NewsArticle">
 	<?php if ( '' !== get_the_post_thumbnail() && ! post_password_required() ) : ?>
-		<div class="entry-thumbnail fadein" aria-hidden="true" role="presentation" tabindex="-1" itemprop="image" itemscope itemtype="https://schema.org/ImageObject">
+		<div class="entry-thumbnail fadein" aria-hidden="true" role="presentation" tabindex="-1">
 			<a href="<?php the_permalink(); ?>"><span class="thumb-wrap"><?php the_post_thumbnail('pirate-rogue-front-small'); ?></span></a>
 		</div>
         <?php elseif ( ! post_password_required() &&  $imagesrc != '') : ?>

--- a/template-parts/content-frontpost-big.php
+++ b/template-parts/content-frontpost-big.php
@@ -66,5 +66,9 @@ if (!isset($thumbfallbackid)) {
                         
 		</div>
 	</div>
-        <?php echo pirate_rogue_create_schema_thumbnail(); ?>
+    <?php 
+        echo pirate_rogue_create_schema_thumbnail(); 
+        echo pirate_rogue_create_schema_postmeta();
+        echo pirate_rogue_create_schema_publisher();
+    ?>
 </article>

--- a/template-parts/content-frontpost-featuredbottom.php
+++ b/template-parts/content-frontpost-featuredbottom.php
@@ -33,5 +33,9 @@ if (!isset($thumbfallbackid)) {
                     ?>
             </header>
 	</div>
-        <?php echo pirate_rogue_create_schema_thumbnail(); ?>
+    <?php 
+        echo pirate_rogue_create_schema_thumbnail(); 
+        echo pirate_rogue_create_schema_postmeta();
+        echo pirate_rogue_create_schema_publisher();
+    ?>
 </article>

--- a/template-parts/content-frontpost-small.php
+++ b/template-parts/content-frontpost-small.php
@@ -30,5 +30,9 @@ if (!isset($thumbfallbackid)) {
                 echo '</a><span class="screen-reader-text"> ('. get_the_date().')</span></h2>';
                 ?>
 	</header>
-        <?php echo pirate_rogue_create_schema_thumbnail(); ?>
+    <?php 
+        echo pirate_rogue_create_schema_thumbnail(); 
+        echo pirate_rogue_create_schema_postmeta();
+        echo pirate_rogue_create_schema_publisher();
+    ?>
 </article>

--- a/template-parts/content-page.php
+++ b/template-parts/content-page.php
@@ -9,16 +9,13 @@
 
 global $pagebreakargs;
 ?>
-    <article id="post-<?php the_ID(); ?>" <?php post_class('cf'); ?> itemscope itemtype="http://schema.org/WebPage">
-	<header class="entry-header">
-		<h1 class="entry-title" itemprop="headline"><?php the_title(); ?></h1>
-	</header>
-	<div class="entry-content" itemprop="text">
-		<?php 
-                    the_content(); 
-                    echo wp_link_pages($pagebreakargs);
-		?>
-	</div>
-	<?php echo pirate_rogue_create_schema_thumbnail(); ?>
-	<?php edit_post_link( esc_html__( 'Edit Page', 'pirate-rogue'), '<div class="edit-link cf">', '</div>' ); ?>
-    </article>
+<header class="entry-header">
+	<h1 class="entry-title"><?php the_title(); ?></h1>
+</header>
+<div class="entry-content">
+<?php
+	the_content();
+	echo wp_link_pages($pagebreakargs);
+?>
+</div>
+<?php edit_post_link( esc_html__( 'Edit Page', 'pirate-rogue'), '<div class="edit-link cf">', '</div>' ); ?>

--- a/template-parts/content-single.php
+++ b/template-parts/content-single.php
@@ -76,17 +76,6 @@ $custom_class = get_post_meta($post->ID, 'post_class', true);
                                     <?php echo wp_link_pages($pagebreakargs);
 					 edit_post_link( esc_html__( 'Edit Post', 'pirate-rogue'), '<span class="entry-edit">', '</span>' ); ?>
 				</div>
-                                <meta itemprop="datePublished" content="<?php echo esc_attr( get_post_time('c',false,$post->ID) );?>">
-                                <meta itemprop="dateModified" content="<?php echo esc_attr( get_the_modified_time('c',false,$post->ID) );?>">
-                                <?php
-                                    $author = get_theme_mod( 'pirate_rogue_author' );      
-                                    if ($author) { ?>
-                                        <div itemprop="author" itemscope itemtype="http://schema.org/Person">
-                                            <meta itemprop="name" content="<?php echo $author; ?>">
-                                        </div>
-                                    <?php }
-                                    echo pirate_rogue_create_schema_publisher();
-                                    ?>
 			</div>
 	</header>
 	<div class="contentwrap">
@@ -170,5 +159,9 @@ $custom_class = get_post_meta($post->ID, 'post_class', true);
 
 	    </div>
 	</div>
-        <?php echo pirate_rogue_create_schema_thumbnail(get_the_ID()); ?>
+    <?php 
+        echo pirate_rogue_create_schema_thumbnail(); 
+        echo pirate_rogue_create_schema_postmeta();
+        echo pirate_rogue_create_schema_publisher();
+    ?>
     </article>

--- a/template-parts/front-section-four.php
+++ b/template-parts/front-section-four.php
@@ -83,7 +83,11 @@
 					</div>
 				</div>
 			</div>
-                        <?php echo pirate_rogue_create_schema_thumbnail(); ?>
+            <?php 
+                echo pirate_rogue_create_schema_thumbnail(); 
+                echo pirate_rogue_create_schema_postmeta();
+                echo pirate_rogue_create_schema_publisher();
+            ?>
 		</article>
 
 		<?php endwhile; ?>

--- a/template-parts/front-section-fourcolumn.php
+++ b/template-parts/front-section-fourcolumn.php
@@ -70,7 +70,11 @@ $uku_section_fourcolumn_query = new WP_Query( array(
 					<div class="entry-summary" itemprop="description">
 						<?php the_excerpt(); ?>
 					</div><!-- end .entry-summary -->
-                                        <?php echo pirate_rogue_create_schema_thumbnail(); ?>
+                                    <?php 
+                                        echo pirate_rogue_create_schema_thumbnail(); 
+                                        echo pirate_rogue_create_schema_postmeta();
+                                        echo pirate_rogue_create_schema_publisher();
+                                    ?>
 				</article><!-- #post-## -->
 
 			<?php endwhile; ?>

--- a/template-parts/front-section-sixcolumn.php
+++ b/template-parts/front-section-sixcolumn.php
@@ -69,7 +69,11 @@ if (!isset($thumbfallbackid)) {
                                     <div class="entry-summary" itemprop="description">
                                             <?php the_excerpt(); ?>
                                     </div><!-- end .entry-summary -->
-                                    <?php echo pirate_rogue_create_schema_thumbnail(); ?>
+                                    <?php 
+                                        echo pirate_rogue_create_schema_thumbnail(); 
+                                        echo pirate_rogue_create_schema_postmeta();
+                                        echo pirate_rogue_create_schema_publisher();
+                                    ?>
 				</article><!-- #post-## -->
 
 			<?php endwhile; ?>

--- a/template-parts/front-section-threecolumn.php
+++ b/template-parts/front-section-threecolumn.php
@@ -64,7 +64,11 @@
 				<div class="entry-summary" itemprop="description">
 			   		<?php the_excerpt(); ?>
 				</div><!-- end .entry-summary -->
-                                <?php echo pirate_rogue_create_schema_thumbnail(); ?>
+                            <?php 
+                                echo pirate_rogue_create_schema_thumbnail(); 
+                                echo pirate_rogue_create_schema_postmeta();
+                                echo pirate_rogue_create_schema_publisher();
+                            ?>
 			</article><!-- #post-## -->
 
 		<?php endwhile; ?>

--- a/template-parts/front-section-twocolumn.php
+++ b/template-parts/front-section-twocolumn.php
@@ -62,7 +62,11 @@ $thumbfallbackid = absint(get_theme_mod( 'pirate_rogue_fallback_thumbnail' ));
                             <div class="entry-summary" itemprop="description">
                                     <?php the_excerpt(); ?>
                             </div><!-- end .entry-summary -->
-                            <?php echo pirate_rogue_create_schema_thumbnail(); ?>
+                            <?php 
+                                echo pirate_rogue_create_schema_thumbnail(); 
+                                echo pirate_rogue_create_schema_postmeta();
+                                echo pirate_rogue_create_schema_publisher();
+                            ?>
 			</article><!-- #post-## -->
 
 		<?php endwhile; ?>


### PR DESCRIPTION
In der BundesPR wurde angemerkt, dass die erzeugten strukturierten Daten verbessert werden könnten.

Beispielsweise gibt das Testtool von Google einige Fehler für piratenpartei.de aus:
https://search.google.com/structured-data/testing-tool/u/0/#url=piratenpartei.de

Als ersten Schritt habe ich versucht, die Fehler zu reduzieren:
* Alle NewsArticle-Einträge sollten nun durchgängig die geforderten Angaben wie `author`, `datePublished`, `publisher`, `dateModified` etc. haben. Mir ist nicht ganz klar, wie man `mainEntityOfPage` füllen könnte. Aber anscheinend empfiehlt das Google vor allem für AMP-Seiten.
* Publisher-Informationen wurden teils mehrfach definiert. Das habe ich vereinheitlicht.
* Die Daten des Fallback-Thumbnails sollte nun korrekt ausgegeben werden.
* Außerdem habe ich die Definition von Seiten als WebPage vorerst entfernt. Dies führt zu Problemen, etwa wenn die Seiten wiederum eine Blogroll einbinden.
* Die Funktionen zum Erstellen der Menü-Eintrage (Menu Walker) und das durch sie produzierte Markup habe ich etwas aufgeräumt.