### PR TITLE
Kleinere Fehlerbehebungen

### DIFF
--- a/content.php
+++ b/content.php
@@ -10,10 +10,9 @@
 ?>
 <?php 
 $thumbfallbackid = absint(get_theme_mod( 'pirate_rogue_fallback_blogroll_thumbnail' ));
-if (!isset($thumbfallbackid)) {
-    $thumbfallbackid =0;
-} else {
-    $imagesrc = wp_get_attachment_image_src( $thumbfallbackid, 'pirate-rogue-standard-blog' )[0];
+$imagesrc = wp_get_attachment_image_src( $thumbfallbackid, 'pirate-rogue-standard-blog' );
+if ($imagesrc) {
+    $imagesrc = $imagesrc[0];
 }
 ?>
     <article id="post-<?php the_ID(); ?>" <?php post_class('cf'); ?>>

--- a/inc/template-tags.php
+++ b/inc/template-tags.php
@@ -286,11 +286,10 @@ function pirate_rogue_get_tag_ID($tag_name) {
         ) );
 
         $thumbfallbackid = absint(get_theme_mod( 'pirate_rogue_fallback_thumbnail' ));
-	if (!isset($thumbfallbackid)) {
-	    $thumbfallbackid =0;
-	} else {
-	    $imagesrc = wp_get_attachment_image_src( $thumbfallbackid, 'pirate-rogue-front-big' )[0];
-	}
+		$imagesrc = wp_get_attachment_image_src( $thumbfallbackid, 'pirate-rogue-front-big' );
+		if ($imagesrc) {
+			$imagesrc = $imagesrc[0];
+		}
 		
         $out = '<section id="front-section-twocolumn" class="cf columns-wrap '.$divclass.'">';
         if (!empty($title)) {

--- a/template-parts/content-blogroll.php
+++ b/template-parts/content-blogroll.php
@@ -10,10 +10,9 @@
 ?>
 <?php 
 $thumbfallbackid = absint(get_theme_mod( 'pirate_rogue_fallback_blogroll_thumbnail' ));
-if (!isset($thumbfallbackid)) {
-    $thumbfallbackid =0;
-} else {
-    $imagesrc = wp_get_attachment_image_src( $thumbfallbackid, 'pirate-rogue-front-small' )[0];
+$imagesrc = wp_get_attachment_image_src( $thumbfallbackid, 'pirate-rogue-front-small' );
+if ($imagesrc) {
+    $imagesrc = $imagesrc[0];
 }
 ?>
 

--- a/template-parts/content-frontpost-big.php
+++ b/template-parts/content-frontpost-big.php
@@ -8,10 +8,9 @@
  */
 
 $thumbfallbackid = absint(get_theme_mod( 'pirate_rogue_fallback_thumbnail' ));
-if (!isset($thumbfallbackid)) {
-    $thumbfallbackid =0;
-} else {
-    $imagesrc = wp_get_attachment_image_src( $thumbfallbackid, 'pirate-rogue-front-big' )[0];
+$imagesrc = wp_get_attachment_image_src( $thumbfallbackid, 'pirate-rogue-front-big' );
+if ($imagesrc) {
+    $imagesrc = $imagesrc[0];
 }
 ?>
      

--- a/template-parts/content-frontpost-featuredbottom.php
+++ b/template-parts/content-frontpost-featuredbottom.php
@@ -8,10 +8,9 @@
  */
 
 $thumbfallbackid = absint(get_theme_mod( 'pirate_rogue_fallback_thumbnail' ));
-if (!isset($thumbfallbackid)) {
-    $thumbfallbackid =0;
-} else {
-    $imagesrc = wp_get_attachment_image_src( $thumbfallbackid, 'pirate-rogue-front-big' )[0];
+$imagesrc = wp_get_attachment_image_src( $thumbfallbackid, 'pirate-rogue-front-big' );
+if ($imagesrc) {
+    $imagesrc = $imagesrc[0];
 }
 ?>
 

--- a/template-parts/content-frontpost-featuredbottom.php
+++ b/template-parts/content-frontpost-featuredbottom.php
@@ -32,7 +32,7 @@ if (!isset($thumbfallbackid)) {
                 echo '</a><span class="screen-reader-text"> ('. get_the_date().')</span></h2>';
                     ?>
             </header>
-            <meta itemprop="description" content="<?php echo get_the_excerpt(); ?>">
+            <meta itemprop="description" content="<?php echo wp_strip_all_tags(get_the_excerpt(), true); ?>">
 	</div>
     <?php 
         echo pirate_rogue_create_schema_thumbnail(); 

--- a/template-parts/content-frontpost-small.php
+++ b/template-parts/content-frontpost-small.php
@@ -9,10 +9,9 @@
  */
 
 $thumbfallbackid = absint(get_theme_mod( 'pirate_rogue_fallback_thumbnail' ));
-if (!isset($thumbfallbackid)) {
-    $thumbfallbackid =0;
-} else {
-    $imagesrc = wp_get_attachment_image_src( $thumbfallbackid, 'pirate-rogue-front-small' )[0];
+$imagesrc = wp_get_attachment_image_src( $thumbfallbackid, 'pirate-rogue-front-small' );
+if ($imagesrc) {
+    $imagesrc = $imagesrc[0];
 }
 ?>
 <article <?php post_class(); ?> itemscope itemtype="http://schema.org/NewsArticle">

--- a/template-parts/content-frontpost-small.php
+++ b/template-parts/content-frontpost-small.php
@@ -30,7 +30,7 @@ if (!isset($thumbfallbackid)) {
                 echo '</a><span class="screen-reader-text"> ('. get_the_date().')</span></h2>';
                 ?>
 	</header>
-	<meta itemprop="description" content="<?php echo get_the_excerpt(); ?>">
+	<meta itemprop="description" content="<?php echo wp_strip_all_tags(get_the_excerpt(), true); ?>">
     <?php 
         echo pirate_rogue_create_schema_thumbnail(); 
         echo pirate_rogue_create_schema_postmeta();

--- a/template-parts/content-single.php
+++ b/template-parts/content-single.php
@@ -60,7 +60,7 @@ $custom_class = get_post_meta($post->ID, 'post_class', true);
 				if ( get_post_meta($post->ID, 'intro', true) ) { ?>
 					<p class="intro" itemprop="description"><?php echo $introtext; ?></p>
 				<?php } else { ?>
-					<meta itemprop="description" content="<?php echo get_the_excerpt(); ?>">
+					<meta itemprop="description" content="<?php echo wp_strip_all_tags(get_the_excerpt(), true); ?>">
 				<?php } ?>
 			</div><!-- end .title-wrap -->
 

--- a/template-parts/front-section-four.php
+++ b/template-parts/front-section-four.php
@@ -65,7 +65,7 @@
                                                 echo '</a><span class="screen-reader-text"> ('. get_the_date().')</span></h2>';
                                                 ?>
 					</header>
-					<meta itemprop="description" content="<?php echo get_the_excerpt(); ?>">
+					<meta itemprop="description" content="<?php echo wp_strip_all_tags(get_the_excerpt(), true); ?>">
 					<div class="entry-meta">
 						<?php pirate_rogue_posted_by(); ?>
 						<span class="entry-date" aria-hidden="true">

--- a/template-parts/front-section-four.php
+++ b/template-parts/front-section-four.php
@@ -28,12 +28,10 @@
 	) );
 	
 	$thumbfallbackid = absint(get_theme_mod( 'pirate_rogue_fallback_thumbnail' ));
-	if (!isset($thumbfallbackid)) {
-	    $thumbfallbackid =0;
-	} else {
-	    $imagesrc = wp_get_attachment_image_src( $thumbfallbackid, 'pirate-rogue-featured' )[0];
+	$imagesrc = wp_get_attachment_image_src( $thumbfallbackid, 'pirate-rogue-featured' );
+	if ($imagesrc) {
+		$imagesrc = $imagesrc[0];
 	}
-	
 ?>
 
 <section id="front-section-four" class="front-section cf">

--- a/template-parts/front-section-fourcolumn.php
+++ b/template-parts/front-section-fourcolumn.php
@@ -25,10 +25,9 @@ $uku_section_fourcolumn_query = new WP_Query( array(
 ) );
 	
 	$thumbfallbackid = absint(get_theme_mod( 'pirate_rogue_fallback_thumbnail' ));
-	if (!isset($thumbfallbackid)) {
-	    $thumbfallbackid =0;
-	} else {
-	    $imagesrc = wp_get_attachment_image_src( $thumbfallbackid, 'pirate-rogue-front-small' )[0];
+	$imagesrc = wp_get_attachment_image_src( $thumbfallbackid, 'pirate-rogue-front-small' );
+	if ($imagesrc) {
+		$imagesrc = $imagesrc[0];
 	}
 ?>
 

--- a/template-parts/front-section-sixcolumn.php
+++ b/template-parts/front-section-sixcolumn.php
@@ -23,10 +23,9 @@ $uku_section_sixcolumn_query = new WP_Query( array(
 	'ignore_sticky_posts' => 1,
 ) );
 $thumbfallbackid = absint(get_theme_mod( 'pirate_rogue_fallback_thumbnail' ));
-if (!isset($thumbfallbackid)) {
-    $thumbfallbackid =0;
-} else {
-    $imagesrc = wp_get_attachment_image_src( $thumbfallbackid, 'pirate-rogue-front-small' )[0];
+$imagesrc = wp_get_attachment_image_src( $thumbfallbackid, 'pirate-rogue-front-small' );
+if ($imagesrc) {
+    $imagesrc = $imagesrc[0];
 }
 ?>
 

--- a/template-parts/front-section-threecolumn.php
+++ b/template-parts/front-section-threecolumn.php
@@ -24,10 +24,9 @@
 	) );
 	
 	$thumbfallbackid = absint(get_theme_mod( 'pirate_rogue_fallback_thumbnail' ));
-	if (!isset($thumbfallbackid)) {
-	    $thumbfallbackid =0;
-	} else {
-	    $imagesrc = wp_get_attachment_image_src( $thumbfallbackid, 'pirate-rogue-front-small' )[0];
+	$imagesrc = wp_get_attachment_image_src( $thumbfallbackid, 'pirate-rogue-front-small' );
+	if ($imagesrc) {
+		$imagesrc = $imagesrc[0];
 	}
 ?>
 

--- a/template-parts/front-section-twocolumn.php
+++ b/template-parts/front-section-twocolumn.php
@@ -23,11 +23,10 @@ $uku_section_twocolumn_query = new WP_Query( array(
 	'ignore_sticky_posts'   => 1,
 ) );
 $thumbfallbackid = absint(get_theme_mod( 'pirate_rogue_fallback_thumbnail' ));
-	if (!isset($thumbfallbackid)) {
-	    $thumbfallbackid =0;
-	} else {
-	    $imagesrc = wp_get_attachment_image_src( $thumbfallbackid, 'pirate-rogue-front-big' )[0];
-	}
+$imagesrc = wp_get_attachment_image_src( $thumbfallbackid, 'pirate-rogue-front-big' );
+if ($imagesrc) {
+    $imagesrc = $imagesrc[0];
+}
 ?>
 
 <section id="front-section-twocolumn" class="front-section columns-wrap cf">


### PR DESCRIPTION
* Vermeide PHP-Notice aufgrund Zugriffs auf undefinierten Arrayindex, sofern keine Platzhalterbilder festgelegt wurden.
* Stelle sicher, dass Beitragsauszüge als Meta-Attributwert (Mikrodaten) keine HTML-Tags enthalten.