### PR TITLE
Switch für Funktion pirate_rogue_comment

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -301,6 +301,7 @@ function pirate_rogue_comment( $comment, $args, $depth ) {
 	$GLOBALS['comment'] = $comment;
 	switch ( $comment->comment_type ) :
 		case '' :
+		case 'comment' :
 	?>
 
 	<li <?php comment_class(); ?> id="li-comment-<?php comment_ID(); ?>">


### PR DESCRIPTION
In der aktuellen Version werden Beitragskommentare nicht (mehr) eingeblendet.
Ursache ist offenbar, dass der "content_type" nicht (mehr) leer übergeben wird, sondern "comment" lautet.

Mit der zusätzlichen Case-Abfrage in Zeile (L304) lässt sich dieser Fehler beheben.